### PR TITLE
Update MoonPay Widget link to buy.moonpay.com in hero.html

### DIFF
--- a/themes/hugo-litecoin-theme/layouts/partials/hero.html
+++ b/themes/hugo-litecoin-theme/layouts/partials/hero.html
@@ -30,7 +30,7 @@
         |
         <a href="#download" class="page-scroll">{{ with .Site.Params.hero.otherversions }}{{ . | markdownify }}{{ end }}</a>
         |
-        <a href="https://buy.moonpay.io/litecoin" class="page-scroll">{{ with .Site.Params.hero.buylitecoin }}{{ . | markdownify }}{{ end }}</a>
+        <a href="https://buy.moonpay.com/litecoin" class="page-scroll">{{ with .Site.Params.hero.buylitecoin }}{{ . | markdownify }}{{ end }}</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
We prefer buy.moonpay.com to .io these days

https://buy.moonpay.com/litecoin